### PR TITLE
Initialize page generator in dummy page generation script

### DIFF
--- a/Scripts/DummyRendering.php
+++ b/Scripts/DummyRendering.php
@@ -1,1 +1,9 @@
 <?php
+\TYPO3\CMS\Frontend\Page\PageGenerator::pagegenInit();
+// Global content object
+$TSFE->newCObj();
+// LIBRARY INCLUSION, TypoScript
+$temp_incFiles = \TYPO3\CMS\Frontend\Page\PageGenerator::getIncFiles();
+foreach ($temp_incFiles as $temp_file) {
+	include_once './' . $temp_file;
+}


### PR DESCRIPTION
Without this, e.g. $TSFE->linkVars is not initialized in
USER_INT (uncached extbase actions) if the page cache is completely
empty due to the missing call to PageGenerator::pagegenInit().

I copied the whole block from index_ts.php including the include
lines to have a consistent environment in that situation if someone
still uses that.
