### PR TITLE
[TASK] Raise the PHP version requirement to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
-      env: TYPO3_BRANCH=TYPO3_6-2
-    - php: 5.4
-      env: TYPO3_BRANCH=TYPO3_6-2
     - php: 5.5
       env: TYPO3_BRANCH=TYPO3_6-2
     - php: 5.6

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,17 +17,17 @@ $EM_CONF[$_EXTKEY] = array (
   'clearCacheOnLoad' => 0,
   'lockType' => '',
   'version' => '1.0.5',
-  'constraints' => 
+  'constraints' =>
   array (
-    'depends' => 
+    'depends' =>
     array (
-      'php' => '5.3.7-7.0.999',
+      'php' => '5.5.0-7.0.999',
       'typo3' => '6.0.0-8.99.99',
     ),
-    'conflicts' => 
+    'conflicts' =>
     array (
     ),
-    'suggests' => 
+    'suggests' =>
     array (
     ),
   ),


### PR DESCRIPTION
PHP 5.3 and 5.4 have been end-of-lifed a long time ago.

Removing PHP 5.3 and 5.4 from the Travis build matrix will help
speed up the builds.