### PR TITLE
[CLEANUP] Code autoformatting

### DIFF
--- a/Classes/Configuration/RecordRenderingConfigurationBuilder.php
+++ b/Classes/Configuration/RecordRenderingConfigurationBuilder.php
@@ -37,6 +37,7 @@ class RecordRenderingConfigurationBuilder
      * @param string $contextRecord
      *
      * @return string[]
+     *
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     public function configurationFor($extensionName, $pluginName, $contextRecord = 'currentPage')
@@ -46,7 +47,7 @@ class RecordRenderingConfigurationBuilder
         $renderingPath = $this->resolveRenderingPath($pluginSignature);
         return array(
             'record' => $tableName . '_' . $uid,
-            'path' => $renderingPath
+            'path' => $renderingPath,
         );
     }
 
@@ -102,7 +103,9 @@ class RecordRenderingConfigurationBuilder
 
     /**
      * @param string $pluginSignature
+     *
      * @return string
+     *
      * @throws ConfigurationBuildingException
      */
     protected function resolveRenderingPath($pluginSignature)
@@ -110,8 +113,9 @@ class RecordRenderingConfigurationBuilder
         $typoScriptRenderingSetup = $this->renderingContext->getFrontendController()->tmpl->setup['tt_content.'];
         if (isset($typoScriptRenderingSetup[$pluginSignature . '.']['20'])) {
             return sprintf('tt_content.%s.20', $pluginSignature);
-        } elseif(isset($typoScriptRenderingSetup['list.']['20.'][$pluginSignature])) {
+        } elseif (isset($typoScriptRenderingSetup['list.']['20.'][$pluginSignature])) {
             return sprintf('tt_content.list.20.%s', $pluginSignature);
         }
         throw new ConfigurationBuildingException(sprintf('Could not determine rendering location for plugin signature "%s"', $pluginSignature), 1466779430);
-    }}
+    }
+}

--- a/Classes/Core/FrontendRenderingProvisioner.php
+++ b/Classes/Core/FrontendRenderingProvisioner.php
@@ -19,6 +19,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 /**
  * Class FrontendRenderingProvisioner
  * Initializes TYPO3 TypoScriptRendering to be prepared for rendering
+ *
  * @see \TYPO3\CMS\Frontend\Page\PageGenerator::pagegenInit()
  * This is a try to only initialize a basic set as not everything in pagegenInit() makes sense in our case.
  * But it might well be that it'd be better to just use the (ugly) API instead.

--- a/Classes/RenderingDispatcher.php
+++ b/Classes/RenderingDispatcher.php
@@ -44,7 +44,6 @@ class RenderingDispatcher
 
     /**
      * @param RequestBuilder $requestBuilder
-     *
      * @param string[] $renderer
      */
     public function __construct(RequestBuilder $requestBuilder = null, array $renderer = null)
@@ -106,9 +105,9 @@ class RenderingDispatcher
      */
     protected function resolveRenderer(Request $request)
     {
-        /** @var RenderingInterface $renderer */
         if ($request->hasArgument('renderer') && isset($this->renderer[$request->getArgument('renderer')])) {
             $rendererClassName = $this->renderer[$request->getArgument('renderer')];
+            /** @var RenderingInterface $renderer */
             $renderer = new $rendererClassName();
             if ($renderer->canRender($request)) {
                 return $renderer;
@@ -116,6 +115,7 @@ class RenderingDispatcher
         }
 
         foreach ($this->renderer as $rendererClassName) {
+            /** @var RenderingInterface $renderer */
             $renderer = new $rendererClassName();
             if ($renderer->canRender($request)) {
                 return $renderer;

--- a/Classes/ViewHelpers/Uri/AjaxActionViewHelper.php
+++ b/Classes/ViewHelpers/Uri/AjaxActionViewHelper.php
@@ -55,6 +55,7 @@ class AjaxActionViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractView
      * @param string $contextRecord The record that the rendering should depend upon. e.g. current (default: record is fetched from current Extbase plugin), tt_content:12 (tt_content record with uid 12), pages:15 (pages record with uid 15), 'currentPage' record of current page
      *
      * @return string Rendered link
+     *
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     public function render($action = null, array $arguments = array(), $controller = null, $extensionName = null, $pluginName = null, $pageUid = null, $section = '', $format = '', $linkAccessRestrictedPages = false, array $additionalParams = array(), $absolute = false, $addQueryString = false, array $argumentsToBeExcludedFromQueryString = array(), $addQueryStringMethod = null, $contextRecord = 'current')
@@ -100,6 +101,7 @@ class AjaxActionViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractView
      * @param string $contextRecord
      *
      * @return string[]
+     *
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     public function buildTypoScriptRenderingConfiguration($extensionName, $pluginName, $contextRecord)

--- a/Classes/ViewHelpers/Widget/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Widget/LinkViewHelper.php
@@ -26,7 +26,6 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
      */
     protected $tagName = 'a';
 
-
     /**
      * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManager
      * @inject
@@ -37,6 +36,7 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
      * Initialize arguments
      *
      * @return void
+     *
      * @api
      */
     public function initializeArguments()
@@ -62,6 +62,7 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
      * @param string $contextRecord The record that the rendering should depend upon. e.g. current (default: record is fetched from current Extbase plugin), tt_content:12 (tt_content record with uid 12), pages:15 (pages record with uid 15), 'currentPage' record of current page
      *
      * @return string The rendered link
+     *
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     public function render($pluginName, $extensionName, $action = null, array $arguments = array(), $section = '', $format = '', $ajax = true, $contextRecord = 'current')
@@ -80,6 +81,7 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
      * Gets the URI for an Ajax Request.
      *
      * @return string the Ajax URI
+     *
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     protected function getAjaxUri()
@@ -160,6 +162,7 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
      * @param string $contextRecord
      *
      * @return string[]
+     *
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     public function buildTypoScriptRenderingConfiguration($extensionName, $pluginName, $contextRecord)

--- a/Classes/ViewHelpers/Widget/UriViewHelper.php
+++ b/Classes/ViewHelpers/Widget/UriViewHelper.php
@@ -31,6 +31,7 @@ class UriViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
      * Initialize arguments
      *
      * @return void
+     *
      * @api
      */
     public function initializeArguments()
@@ -51,6 +52,7 @@ class UriViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
      * @param string $contextRecord The record that the rendering should depend upon. e.g. current (default: record is fetched from current Extbase plugin), tt_content:12 (tt_content record with uid 12), pages:15 (pages record with uid 15), 'currentPage' record of current page
      *
      * @return string The rendered link
+     *
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     public function render($pluginName, $extensionName, $action = null, array $arguments = array(), $section = '', $format = '', $ajax = true, $contextRecord = 'current')
@@ -66,6 +68,7 @@ class UriViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
      * Get the URI for an Ajax Request.
      *
      * @return string the Ajax URI
+     *
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     protected function getAjaxUri()
@@ -146,6 +149,7 @@ class UriViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
      * @param string $contextRecord
      *
      * @return string[]
+     *
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     public function buildTypoScriptRenderingConfiguration($extensionName, $pluginName, $contextRecord)

--- a/Tests/Functional/AbstractRenderingTestCase.php
+++ b/Tests/Functional/AbstractRenderingTestCase.php
@@ -65,7 +65,7 @@ abstract class AbstractRenderingTestCase extends FunctionalTestCase
     {
         $page = array(
             'uid' => $pageId,
-            'title' => 'root'
+            'title' => 'root',
         );
         $this->getDatabaseConnection()->exec_INSERTquery('pages', $page);
         parent::setUpFrontendRootPage($pageId, array('EXT:typoscript_rendering/Tests/Functional/Fixtures/Frontend/Basic.ts'));

--- a/Tests/Unit/Configuration/RecordRenderingConfigurationBuilderTest.php
+++ b/Tests/Unit/Configuration/RecordRenderingConfigurationBuilderTest.php
@@ -46,13 +46,13 @@ class RecordRenderingConfigurationBuilderTest extends UnitTestCase
                     '20.' => array(
                         'news_pi1' => 'USER',
                         'news_pi1.' => array(),
-                    )
+                    ),
                 ),
                 'news_pi2.' => array(
                     '20' => 'USER',
-                    '20.' => array()
-                )
-            )
+                    '20.' => array(),
+                ),
+            ),
         );
     }
 

--- a/Tests/Unit/Renderer/RecordRendererTest.php
+++ b/Tests/Unit/Renderer/RecordRendererTest.php
@@ -87,7 +87,7 @@ class RecordRendererTest extends UnitTestCase
             'root page' => array(
                 array('path' => ''),
                 array('dontCheckPid' => '1', 'source' => 'pages_1', 'tables' => 'pages'),
-                '1'
+                '1',
             ),
         );
     }
@@ -111,7 +111,7 @@ class RecordRendererTest extends UnitTestCase
                     array(
                         'uid' => '1',
                         'pid' => '0',
-                    )
+                    ),
                 )
         );
         $tsfeMock->id = $pageId;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,7 +7,7 @@ call_user_func(function ($packageKey) {
 
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['typoscript_rendering'] = array();
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['typoscript_rendering']['renderClasses'] = array(
-        'record' => 'Helhum\\TyposcriptRendering\\Renderer\\RecordRenderer'
+        'record' => 'Helhum\\TyposcriptRendering\\Renderer\\RecordRenderer',
     );
 
 }, $_EXTKEY);


### PR DESCRIPTION
Also move and @var annotation to directly before the creation of the
variable allow php-cs-fixer to recognize it as a documentation comment.