### PR TITLE
[BUGFIX] add TYPO3 9 compatibility for Widget ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/Widget/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Widget/LinkViewHelper.php
@@ -17,7 +17,7 @@ namespace Helhum\TyposcriptRendering\ViewHelpers\Widget;
 use Helhum\TyposcriptRendering\Configuration\RecordRenderingConfigurationBuilder;
 use Helhum\TyposcriptRendering\Renderer\RenderingContext;
 
-class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper
+class LinkViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Widget\LinkViewHelper
 {
     /**
      * @var string
@@ -39,32 +39,22 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
      */
     public function initializeArguments()
     {
-        $this->registerUniversalTagAttributes();
-        $this->registerTagAttribute('name', 'string', 'Specifies the name of an anchor');
-        $this->registerTagAttribute('rel', 'string', 'Specifies the relationship between the current document and the linked document');
-        $this->registerTagAttribute('rev', 'string', 'Specifies the relationship between the linked document and the current document');
-        $this->registerTagAttribute('target', 'string', 'Specifies where to open the linked document');
-        $this->registerArgument('addQueryStringMethod', 'string', 'Method to be used for query string');
+        parent::initializeArguments();
+        $this->registerArgument('extensionName', 'string', 'The extension that the rendering should depend upon.', true);
+        $this->registerArgument('pluginName', 'string', 'The plugin that the rendering should depend upon.', true);
+        $this->registerArgument('contextRecord', 'string', 'The record that the rendering should depend upon. e.g. current (default: record is fetched from current Extbase plugin), tt_content:12 (tt_content record with uid 12), pages:15 (pages record with uid 15), \'currentPage\' record of current page');
     }
 
     /**
      * Render the Uri.
      *
-     * @param string $pluginName
-     * @param string $extensionName
-     * @param string $action Target action
-     * @param array $arguments Arguments
-     * @param string $section The anchor to be added to the URI
-     * @param string $format The requested format, e.g. ".html
-     * @param bool $ajax true if the URI should be to an Ajax widget, false otherwise.
-     * @param string $contextRecord The record that the rendering should depend upon. e.g. current (default: record is fetched from current Extbase plugin), tt_content:12 (tt_content record with uid 12), pages:15 (pages record with uid 15), 'currentPage' record of current page
-     *
-     * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      * @return string The rendered link
-     *
+     * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
-    public function render($pluginName, $extensionName, $action = null, array $arguments = [], $section = '', $format = '', $ajax = true, $contextRecord = 'current')
+    public function render()
     {
+        $ajax = $this->arguments['ajax'];
+
         if ($ajax === true) {
             $uri = $this->getAjaxUri();
         } else {
@@ -78,9 +68,9 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
     /**
      * Gets the URI for an Ajax Request.
      *
-     * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      * @return string the Ajax URI
      *
+     * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     protected function getAjaxUri()
     {
@@ -108,48 +98,10 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
             ->setArguments(array_merge([$argumentPrefix => $arguments], $additionalParams))
             ->setSection($this->arguments['section'])
             ->setAddQueryString(true)
+            ->setAddQueryStringMethod($this->arguments['addQueryStringMethod'])
             ->setArgumentsToBeExcludedFromQueryString([$argumentPrefix, 'cHash'])
             ->setFormat($this->arguments['format'])
             ->setUseCacheHash(true);
-
-        // TYPO3 6.0 compatibility check:
-        if (method_exists($uriBuilder, 'setAddQueryStringMethod')) {
-            $uriBuilder->setAddQueryStringMethod($this->arguments['addQueryStringMethod']);
-        }
-
-        return $uriBuilder->build();
-    }
-
-    /**
-     * Gets the URI for a non-Ajax Request.
-     *
-     * @return string the Widget URI
-     */
-    protected function getWidgetUri()
-    {
-        $uriBuilder = $this->controllerContext->getUriBuilder();
-        $argumentPrefix = $this->controllerContext->getRequest()->getArgumentPrefix();
-        $arguments = $this->hasArgument('arguments') ? $this->arguments['arguments'] : [];
-        if ($this->hasArgument('action')) {
-            $arguments['action'] = $this->arguments['action'];
-        }
-        if ($this->hasArgument('format') && $this->arguments['format'] !== '') {
-            $arguments['format'] = $this->arguments['format'];
-        }
-        if ($this->hasArgument('addQueryStringMethod') && $this->arguments['addQueryStringMethod'] !== '') {
-            $arguments['addQueryStringMethod'] = $this->arguments['addQueryStringMethod'];
-        }
-        $uriBuilder->reset()
-            ->setArguments([$argumentPrefix => $arguments])
-            ->setSection($this->arguments['section'])
-            ->setAddQueryString(true)
-            ->setArgumentsToBeExcludedFromQueryString([$argumentPrefix, 'cHash'])
-            ->setFormat($this->arguments['format']);
-
-        // TYPO3 6.0 compatibility check:
-        if (method_exists($uriBuilder, 'setAddQueryStringMethod')) {
-            $uriBuilder->setAddQueryStringMethod($this->arguments['addQueryStringMethod']);
-        }
 
         return $uriBuilder->build();
     }
@@ -158,10 +110,8 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedVi
      * @param string $extensionName
      * @param string $pluginName
      * @param string $contextRecord
-     *
-     * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      * @return string[]
-     *
+     * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     public function buildTypoScriptRenderingConfiguration($extensionName, $pluginName, $contextRecord)
     {

--- a/Classes/ViewHelpers/Widget/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Widget/LinkViewHelper.php
@@ -48,8 +48,8 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Widget\LinkViewHelper
     /**
      * Render the Uri.
      *
-     * @return string The rendered link
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
+     * @return string The rendered link
      */
     public function render()
     {
@@ -68,9 +68,9 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Widget\LinkViewHelper
     /**
      * Gets the URI for an Ajax Request.
      *
+     * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      * @return string the Ajax URI
      *
-     * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
      */
     protected function getAjaxUri()
     {
@@ -110,8 +110,8 @@ class LinkViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Widget\LinkViewHelper
      * @param string $extensionName
      * @param string $pluginName
      * @param string $contextRecord
-     * @return string[]
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
+     * @return string[]
      */
     public function buildTypoScriptRenderingConfiguration($extensionName, $pluginName, $contextRecord)
     {

--- a/Classes/ViewHelpers/Widget/UriViewHelper.php
+++ b/Classes/ViewHelpers/Widget/UriViewHelper.php
@@ -47,8 +47,8 @@ class UriViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Widget\UriViewHelper
      *
      * @param RenderingContextInterface $renderingContext
      * @param array $arguments
-     * @return string the AJAX URI
      * @throws \Helhum\TyposcriptRendering\Configuration\ConfigurationBuildingException
+     * @return string the AJAX URI
      */
     protected static function getAjaxUri(RenderingContextInterface $renderingContext, array $arguments)
     {


### PR DESCRIPTION
The Widget ViewHelpers are currently not useable for the TYPO3 9 version.

- extended from default Fluid Widget LinkViewHelper/UriViewHelper (for default arguments and default getWidgetUri function) and added the custom arguments for the ViewHelper.
- removed TYPO3 6 compatibility check
- remove function arguments from render functions since not accepted anymore in TYPO3 9
- make functions static to use trait CompileWithRenderStatic from extended UriViewHelper
