### PR TITLE
[BUGFIX] Use rootline utility to retrieve rootline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - phpenv config-rm xdebug.ini
 
 install:
-  - composer require typo3/minimal=$TYPO3_VERSION
+  - composer require --dev typo3/minimal=$TYPO3_VERSION
 
 script:
   - >
@@ -51,6 +51,21 @@ script:
 jobs:
   fast_finish: true
   include:
+    - stage: test
+      php: 7.4
+      env: TYPO3_VERSION=^10.4
+    - stage: test
+      php: 7.3
+      env: TYPO3_VERSION=^10.4
+    - stage: test
+      php: 7.2
+      env: TYPO3_VERSION=^10.4
+    - stage: test
+      php: 7.4
+      env: TYPO3_VERSION=^9.5
+    - stage: test
+      php: 7.3
+      env: TYPO3_VERSION=^9.5
     - stage: test
       php: 7.2
       env: TYPO3_VERSION=^9.5

--- a/Classes/Renderer/RecordRenderer.php
+++ b/Classes/Renderer/RecordRenderer.php
@@ -16,6 +16,7 @@ namespace Helhum\TyposcriptRendering\Renderer;
 use Helhum\TyposcriptRendering\Mvc\Request;
 use Helhum\TyposcriptRendering\Mvc\Response;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
@@ -84,7 +85,7 @@ class RecordRenderer implements RenderingInterface
 
         if ($table === 'pages') {
             // Allow rendering of a root page which has pid === 0 and would be denied otherwise
-            $rootLine = $renderingContext->getFrontendController()->sys_page->getRootLine($id);
+            $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $id)->get();
             // $rootLine[0] is the root page. Check if the page we're going to render is a root page.
             // We explicitly ignore the case where the to be rendered id is in another root line (multi domain setup)
             // as this would require an additional record lookup. The use case for this is very limited anyway

--- a/Tests/Unit/Renderer/RecordRendererTest.php
+++ b/Tests/Unit/Renderer/RecordRendererTest.php
@@ -17,6 +17,8 @@ use Helhum\TyposcriptRendering\Mvc\Request;
 use Helhum\TyposcriptRendering\Renderer\RecordRenderer;
 use Helhum\TyposcriptRendering\Renderer\RenderingContext;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
@@ -32,6 +34,11 @@ class RecordRendererTest extends UnitTestCase
     protected function setUp()
     {
         $this->renderer = $this->getAccessibleMock('Helhum\\TyposcriptRendering\\Renderer\\RecordRenderer', ['dummy']);
+    }
+
+    protected function tearDown()
+    {
+        GeneralUtility::purgeInstances();
     }
 
     /**
@@ -102,11 +109,11 @@ class RecordRendererTest extends UnitTestCase
     public function configurationIsGeneratedCorrectlyFromRequest(array $requestArguments, array $expectedConfiguration, $pageId = '42')
     {
         /** @var TypoScriptFrontendController|\PHPUnit_Framework_MockObject_MockObject $tsfeMock */
-        $tsfeMock = $this->getMockBuilder('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController')
+        $tsfeMock = $this->getMockBuilder(TypoScriptFrontendController::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $pageRepositoryMock = $this->getMockBuilder('TYPO3\\CMS\\Frontend\\Page\\PageRepository')->disableOriginalConstructor()->getMock();
-        $pageRepositoryMock->expects($this->any())->method('getRootLine')->willReturn(
+        $rootlineUtilityMock = $this->getMockBuilder(RootlineUtility::class)->disableOriginalConstructor()->getMock();
+        $rootlineUtilityMock->expects($this->any())->method('get')->willReturn(
                 [
                     [
                         'uid' => '1',
@@ -114,8 +121,8 @@ class RecordRendererTest extends UnitTestCase
                     ],
                 ]
         );
+        GeneralUtility::addInstance(RootlineUtility::class, $rootlineUtilityMock);
         $tsfeMock->id = $pageId;
-        $tsfeMock->sys_page = $pageRepositoryMock;
         $contextFixture = new RenderingContext($tsfeMock);
         $requestFixture = new Request($requestArguments);
 

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": "^7.2",
-        "typo3/cms-core": "^9.5"
+        "typo3/cms-core": "^9.5 || ^10.4"
     },
     "require-dev": {
-        "nimut/testing-framework": "^4.0",
+        "nimut/testing-framework": "^4.0 || ^5.0",
         "typo3/minimal": "^9.5"
     },
     "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,8 +13,8 @@ $EM_CONF[$_EXTKEY] = [
   'version' => '2.2.2',
   'constraints' => [
     'depends' => [
-      'php' => '7.2.0-7.3.999',
-      'typo3' => '9.5.0-9.5.99',
+      'php' => '7.2.0-7.4.999',
+      'typo3' => '9.5.0-10.4.99',
     ],
     'conflicts' => [
     ],


### PR DESCRIPTION
Since the new API is available in TYPO3 9.5 and the
old was removed in 10.4, we need to use the new API now.