### PR TITLE
Adds value for missing argument "extensionName"

### DIFF
--- a/Classes/ViewHelpers/Link/CObjectViewHelper.php
+++ b/Classes/ViewHelpers/Link/CObjectViewHelper.php
@@ -69,10 +69,15 @@ class CObjectViewHelper extends AbstractTagBasedViewHelper
      */
     public function render()
     {
+        $arguments = $this->arguments;
+        // We need to set a dummy name here, otherwise Extbase will bail out when trying to determine the
+        // plugin name from the request, which isn't set when in Extbase context
+        // For this view helper, we don't need this anyway, so we set this to a dummy value
+        $arguments['extensionName'] = 'DummyName';
         $uri = (new TyposcriptRenderingUri())->withViewHelperContext(
             new ViewHelperContext(
                 $this->renderingContext,
-                $this->arguments
+                $arguments
             )
         );
 

--- a/Classes/ViewHelpers/Uri/CObjectViewHelper.php
+++ b/Classes/ViewHelpers/Uri/CObjectViewHelper.php
@@ -61,6 +61,10 @@ class CObjectViewHelper extends AbstractViewHelper
 
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
+        // We need to set a dummy name here, otherwise Extbase will bail out when trying to determine the
+        // plugin name from the request, which isn't set when in Extbase context
+        // For this view helper, we don't need this anyway, so we set this to a dummy value
+        $arguments['extensionName'] = 'DummyName';
         $uri = (new TyposcriptRenderingUri())->withViewHelperContext(
             new ViewHelperContext(
                 $renderingContext,


### PR DESCRIPTION
In TyposcriptRenderingUri.php, the argument "extensionName" is passed to $uriBuilder->uriFor (line 109). When using the t:link.cObject-ViewHelper, this results in an exception: 
Argument 1 passed to TYPO3\CMS\Extbase\Service\ExtensionService::getTargetPidByPlugin() must be of the type string, null given, called in /typo3_src-10.4.6/typo3/sysext/extbase/Classes/Mvc/Web/Routing/UriBuilder.php on line 618
This commit sets an empty string if extensionName is null.