### PR TITLE
[TASK] Add an `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This configuration has been copied from the TYPO3 coding standards
package.

This allows IDE to use the correct indentation style when editing
files.