### PR TITLE
fix h:uri.action viewhelper - $uriBuilder->setRequest($request)

### DIFF
--- a/Classes/Uri/TyposcriptRenderingUri.php
+++ b/Classes/Uri/TyposcriptRenderingUri.php
@@ -82,7 +82,7 @@ class TyposcriptRenderingUri extends Uri
         $additionalParams['tx_typoscriptrendering']['context'] = json_encode($renderingConfiguration);
 
         $uriBuilder = GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder::class);
-        $uriBuilder->reset();
+        $uriBuilder->reset()->setRequest($request);
         if (is_callable([$uriBuilder, 'setUseCacheHash'])) {
             $uriBuilder->setUseCacheHash(true);
         }


### PR DESCRIPTION
Hi Helmut,
please merge this little change. I still use the viewhelper for AJAX uri generation in some projects. It is simple and straightforward. The missing request object with the uribuilder prevents it from working with TYPO3v12. Thx.
Henri Nathanson